### PR TITLE
feat(demo): word count modal in Tools menu (TEC-2705)

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -4,7 +4,14 @@
 <head>
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <!-- viewport-fit=cover + the apple-mobile-web-app metas mirror the consumer
+       app's standalone PWA setup: add the demo to an iPhone home screen and it
+       opens edge-to-edge with a real env(safe-area-inset-bottom), so the
+       footer ↔ mobile-tab-panel safe-area pairing is testable from the
+       package repo alone. -->
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <title>Demo - Ddoc Editor - Fileverse</title>
 </head>
 

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -15,6 +15,7 @@ import { deriveCapabilities } from './components/second-level-nav/capabilities';
 import { createDemoAppActions } from './components/second-level-nav/demo-app-actions';
 import { LinkModal } from './components/LinkModal';
 import { WordCountModal } from './components/WordCountModal';
+import { DemoFooter } from './components/DemoFooter';
 
 const demoFonts: FontDescriptor[] = [
   {
@@ -917,6 +918,7 @@ function App() {
         setWordCount={setWordCount}
         setPageCount={setPageCount}
       />
+      <DemoFooter wordCount={wordCount} pageCount={pageCount} />
       <WordCountModal
         open={wordCountModalOpen}
         onOpenChange={setWordCountModalOpen}

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -14,6 +14,7 @@ import { demoMenuTree } from './components/second-level-nav/menu-tree';
 import { deriveCapabilities } from './components/second-level-nav/capabilities';
 import { createDemoAppActions } from './components/second-level-nav/demo-app-actions';
 import { LinkModal } from './components/LinkModal';
+import { WordCountModal } from './components/WordCountModal';
 
 const demoFonts: FontDescriptor[] = [
   {
@@ -176,6 +177,7 @@ function App() {
   const [characterCount, setCharacterCount] = useState(0);
   const [wordCount, setWordCount] = useState(0);
   const [pageCount, setPageCount] = useState(0);
+  const [wordCountModalOpen, setWordCountModalOpen] = useState(false);
 
   // --- Title with persistence ---
   const [title, setTitle] = useState(() => {
@@ -522,6 +524,7 @@ function App() {
       documentStyling,
       setDocumentStyling,
       startPresentation: () => setIsPresentationMode(true),
+      openWordCountModal: () => setWordCountModalOpen(true),
     });
 
     return (
@@ -913,6 +916,13 @@ function App() {
         setCharacterCount={setCharacterCount}
         setWordCount={setWordCount}
         setPageCount={setPageCount}
+      />
+      <WordCountModal
+        open={wordCountModalOpen}
+        onOpenChange={setWordCountModalOpen}
+        pageCount={pageCount}
+        wordCount={wordCount}
+        characterCount={characterCount}
       />
       <LinkModal
         open={linkModalOpen}

--- a/demo/src/components/DemoFooter.tsx
+++ b/demo/src/components/DemoFooter.tsx
@@ -1,0 +1,33 @@
+// Demo analog of the consumer app's footer (ddocs.new
+// components/footer/footer.tsx) — same 24px bar, same classes, including the
+// safe-area bottom padding that grows by the iOS home-indicator inset in
+// home-screen (standalone) installs. Exists so the footer ↔ mobile-tab-panel
+// pairing (panel fixed at calc(24px + env(safe-area-inset-bottom)))
+// can be tested against the package alone, without running the app.
+type Props = {
+  wordCount: number;
+  pageCount: number;
+};
+
+export function DemoFooter({ wordCount, pageCount }: Props) {
+  return (
+    <div
+      data-testid="demo-footer"
+      className="w-full color-bg-secondary fixed border-t-[1px] color-border-default color-text-default text-[12px] leading-[16px] right-0 bottom-0 flex justify-end xl:!justify-between items-start pt-1 pb-[calc(0.25rem+env(safe-area-inset-bottom,0px))] px-3 md:!px-6 z-40"
+    >
+      <p className="hidden xl:!block">P2P. Decentralised. Encrypted.</p>
+      <div className="flex items-center gap-2 lg:!gap-4">
+        <div className="flex gap-1 items-center">
+          <p>Words:</p>
+          <span className="tabular-nums">{wordCount}</span>
+        </div>
+        <div className="flex gap-1 items-center">
+          <p>Pages:</p>
+          <span className="tabular-nums">
+            {pageCount <= 1 ? pageCount : `~${pageCount}`}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/demo/src/components/WordCountModal.tsx
+++ b/demo/src/components/WordCountModal.tsx
@@ -1,10 +1,17 @@
-import { DynamicModal, LucideIcon } from '@fileverse/ui';
+import { Button, DynamicModal, LucideIcon } from '@fileverse/ui';
 import { useMediaQuery } from 'usehooks-ts';
 
 // Tools ▸ Word count modal (TEC-2705) — demo analog of the consumer app's
 // components/word-count-modal/word-count-modal.tsx. Counts come from
 // App.tsx's local state (fed by DdocEditor's setCharacterCount/setWordCount/
 // setPageCount), so the values stay live while the modal is open.
+//
+// Styling follows the Figma DS modal (node 20937:452105) rather than
+// DynamicModal's defaults: 12px radius, 330px width, and the OK action on a
+// bg-secondary strip with a top border — DynamicModal's own DialogFooter
+// renders on plain white, so the footer lives inside `content` and
+// primaryAction is unused. The strip (and OK) is desktop-only: the mobile
+// bottom sheet has no OK in the design, dismissal is the X / swipe-down.
 type Props = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -14,9 +21,19 @@ type Props = {
 };
 
 const CountRow = ({ label, value }: { label: string; value: number }) => (
-  <div className="flex justify-between items-center py-3 border-b color-border-default">
-    <p>{label}</p>
-    <span className="color-text-secondary tabular-nums">{value}</span>
+  <div className="flex justify-between items-center p-2 w-full">
+    <p className="leading-5">{label}</p>
+    <span className="text-[12px] leading-4 font-medium color-text-disabled tabular-nums">
+      {value}
+    </span>
+  </div>
+);
+
+// Filled 1px rule (the `color-border-default` utility only sets
+// border-color, so a divider div needs the raw token as a background).
+const RowDivider = () => (
+  <div className="py-1 w-full">
+    <div className="h-px w-full bg-[hsl(var(--color-border-default))]" />
   </div>
 );
 
@@ -27,38 +44,48 @@ export const WordCountModal = ({
   wordCount,
   characterCount,
 }: Props) => {
-  // Same breakpoint DynamicModal itself switches to the bottom-sheet at: the
-  // sheet variant has no OK button (Figma), dismissal is the X / swipe-down.
+  // Same breakpoint DynamicModal itself switches to the bottom-sheet at.
   const isMobile = useMediaQuery('(max-width: 768px)');
 
   return (
     <DynamicModal
       open={open}
       onOpenChange={(o: boolean) => !o && onOpenChange(false)}
-      title="Word count"
+      title={<span className="text-heading-sm">Word count</span>}
       hasCloseIcon
-      className="md:!max-w-[360px]"
+      // !pb-0 lets the footer strip sit flush with the dialog's bottom edge
+      // (DialogContent's own pb-4 would leave a white band under it).
+      className="md:!max-w-[330px] md:!rounded-[12px] md:!pb-0 md:overflow-hidden"
+      contentClassName="!p-0"
       content={
         <div className="flex flex-col w-full">
-          <CountRow label="Pages" value={pageCount} />
-          <CountRow label="Words" value={wordCount} />
-          <CountRow label="Characters" value={characterCount} />
-          <div className="flex gap-2 pt-3 pb-1 color-text-secondary">
-            <LucideIcon name="Info" size="sm" className="shrink-0 mt-[1px]" />
-            <p className="text-helper-sm">
-              Word count is displayed bottom right of your documents
-            </p>
+          <div className="flex flex-col gap-4 p-4 w-full">
+            <div className="flex flex-col gap-[2px] w-full">
+              <CountRow label="Pages" value={pageCount} />
+              <RowDivider />
+              <CountRow label="Words" value={wordCount} />
+              <RowDivider />
+              <CountRow label="Characters" value={characterCount} />
+              <RowDivider />
+            </div>
+            <div className="flex gap-2 items-start w-full">
+              <LucideIcon name="Info" size="sm" className="shrink-0 mt-[2px]" />
+              <p className="leading-5">
+                Word count is displayed bottom right of your documents
+              </p>
+            </div>
           </div>
+          {!isMobile && (
+            <div className="w-full color-bg-secondary border-t color-border-default px-4 py-3 flex justify-end">
+              <Button
+                onClick={() => onOpenChange(false)}
+                className="min-w-[80px]"
+              >
+                OK
+              </Button>
+            </div>
+          )}
         </div>
-      }
-      primaryAction={
-        isMobile
-          ? undefined
-          : {
-              label: 'OK',
-              onClick: () => onOpenChange(false),
-              className: 'min-w-[80px]',
-            }
       }
     />
   );

--- a/demo/src/components/WordCountModal.tsx
+++ b/demo/src/components/WordCountModal.tsx
@@ -1,0 +1,65 @@
+import { DynamicModal, LucideIcon } from '@fileverse/ui';
+import { useMediaQuery } from 'usehooks-ts';
+
+// Tools ▸ Word count modal (TEC-2705) — demo analog of the consumer app's
+// components/word-count-modal/word-count-modal.tsx. Counts come from
+// App.tsx's local state (fed by DdocEditor's setCharacterCount/setWordCount/
+// setPageCount), so the values stay live while the modal is open.
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  pageCount: number;
+  wordCount: number;
+  characterCount: number;
+};
+
+const CountRow = ({ label, value }: { label: string; value: number }) => (
+  <div className="flex justify-between items-center py-3 border-b color-border-default">
+    <p>{label}</p>
+    <span className="color-text-secondary tabular-nums">{value}</span>
+  </div>
+);
+
+export const WordCountModal = ({
+  open,
+  onOpenChange,
+  pageCount,
+  wordCount,
+  characterCount,
+}: Props) => {
+  // Same breakpoint DynamicModal itself switches to the bottom-sheet at: the
+  // sheet variant has no OK button (Figma), dismissal is the X / swipe-down.
+  const isMobile = useMediaQuery('(max-width: 768px)');
+
+  return (
+    <DynamicModal
+      open={open}
+      onOpenChange={(o: boolean) => !o && onOpenChange(false)}
+      title="Word count"
+      hasCloseIcon
+      className="md:!max-w-[360px]"
+      content={
+        <div className="flex flex-col w-full">
+          <CountRow label="Pages" value={pageCount} />
+          <CountRow label="Words" value={wordCount} />
+          <CountRow label="Characters" value={characterCount} />
+          <div className="flex gap-2 pt-3 pb-1 color-text-secondary">
+            <LucideIcon name="Info" size="sm" className="shrink-0 mt-[1px]" />
+            <p className="text-helper-sm">
+              Word count is displayed bottom right of your documents
+            </p>
+          </div>
+        </div>
+      }
+      primaryAction={
+        isMobile
+          ? undefined
+          : {
+              label: 'OK',
+              onClick: () => onOpenChange(false),
+              className: 'min-w-[80px]',
+            }
+      }
+    />
+  );
+};

--- a/demo/src/components/second-level-nav/demo-app-actions.ts
+++ b/demo/src/components/second-level-nav/demo-app-actions.ts
@@ -27,6 +27,7 @@ export type DemoAppActionDeps = {
   documentStyling: DocumentStyling | undefined;
   setDocumentStyling: (s: DocumentStyling) => void;
   startPresentation: () => void;
+  openWordCountModal: () => void;
 };
 
 /** Plain factory (not a hook) — safe to call inside renderNavbar's closure. */
@@ -93,4 +94,7 @@ export const createDemoAppActions = (d: DemoAppActionDeps): ActionRegistry => ({
     current: d.documentStyling?.orientation ?? 'portrait',
   },
   'tools.slides': { run: () => d.startPresentation() },
+  // Word count modal (TEC-2705) — demo/src/components/WordCountModal.tsx,
+  // mirroring the consumer app's `tools.wordCount` (editor-ui-store flag).
+  'tools.wordCount': { run: () => d.openWordCountModal() },
 });

--- a/demo/src/components/second-level-nav/menu-tree.tsx
+++ b/demo/src/components/second-level-nav/menu-tree.tsx
@@ -795,6 +795,14 @@ export const demoMenuTree: MenuBarTree = [
         action: 'tools.slides',
         visibleWhen: canTools,
       },
+      {
+        id: 'tools.wordCount',
+        kind: 'action',
+        label: 'Word count',
+        icon: 'FileText',
+        action: 'tools.wordCount',
+        visibleWhen: canTools,
+      },
     ],
   },
 ];

--- a/demo/src/components/second-level-nav/menu-tree.tsx
+++ b/demo/src/components/second-level-nav/menu-tree.tsx
@@ -788,19 +788,19 @@ export const demoMenuTree: MenuBarTree = [
     label: 'Tools',
     children: [
       {
-        id: 'tools.slides',
-        kind: 'action',
-        label: 'Slides',
-        icon: 'Presentation',
-        action: 'tools.slides',
-        visibleWhen: canTools,
-      },
-      {
         id: 'tools.wordCount',
         kind: 'action',
         label: 'Word count',
         icon: 'FileText',
         action: 'tools.wordCount',
+        visibleWhen: canTools,
+      },
+      {
+        id: 'tools.slides',
+        kind: 'action',
+        label: 'Slides',
+        icon: 'Presentation',
+        action: 'tools.slides',
         visibleWhen: canTools,
       },
     ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package/components/tabs/document-mobile-tab-panel.tsx
+++ b/package/components/tabs/document-mobile-tab-panel.tsx
@@ -208,11 +208,14 @@ export const DocumentMobileTabPanel = ({
       data-testid="mobile-tab-panel"
       className={cn('fixed w-full flex flex-col z-[9]')}
       style={{
+        // 24px = the consumer app's footer height; the env() term keeps the
+        // panel above the iOS home indicator in home-screen (standalone)
+        // installs, where the footer grows by the same inset (0 elsewhere).
         bottom: isVersionHistoryMode
           ? 'var(--version-sheet-bottom, 24px)'
           : isFocusMode
-            ? '0px'
-            : '24px',
+            ? 'env(safe-area-inset-bottom, 0px)'
+            : 'calc(24px + env(safe-area-inset-bottom, 0px))',
       }}
     >
       <div


### PR DESCRIPTION
https://linear.app/fileverse/issue/TEC-2705/improve-word-count-visibility

Demo-only mirror of the consumer app's word count modal (ddocs.new#1080): Tools ▸ Word count in the demo's second-level nav, opening a Pages / Words / Characters modal fed by App.tsx's existing count state (setCharacterCount/setWordCount/setPageCount). No package/ changes.

Second-level-nav tests pass (44/44).