### PR TITLE
TEC-2958

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "4.8.13",
+  "version": "4.8.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "4.8.13",
+      "version": "4.8.14",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "4.8.13",
+  "version": "4.8.14",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/fileverse/fileverse-ddocs.git"

--- a/package/components/editor-utils.test.tsx
+++ b/package/components/editor-utils.test.tsx
@@ -152,9 +152,7 @@ describe('Copy HTML export', () => {
 
     expect(writeText).toHaveBeenCalledOnce();
     const copiedHtml = writeText.mock.calls[0][0];
-    expect(copiedHtml).toContain('Hello');
-    expect(copiedHtml).toContain('<strong');
-    expect(copiedHtml).toContain('world</strong>');
+    expect(copiedHtml).toBe('<p>Hello <strong>world</strong></p>');
     expect(copiedHtml).not.toMatch(/<html|<head|<body|<style/i);
     expect(copy).not.toHaveBeenCalled();
     expect(toast).toHaveBeenCalledOnce();

--- a/package/components/editor-utils.tsx
+++ b/package/components/editor-utils.tsx
@@ -56,6 +56,7 @@ import { IpfsImageFetchPayload, IpfsImageUploadResponse } from '../types';
 import { getTemporaryEditor } from '../utils/helpers';
 import { extractTitleFromContent } from '../utils/extract-title-from-content';
 import { getContrastColor } from '../utils/color-utils';
+import { formatAo3Html } from '../utils/format-ao3-html';
 import { parseHeadingLink } from '../utils/heading-link';
 import { setShowReplacePopoverWithData } from '../extensions/search-replace/utils';
 import copy from 'copy-to-clipboard';
@@ -764,8 +765,9 @@ export const useEditorToolbar = ({
   const copyAo3Html: CopyAo3Html = useCallback(
     async (getHtml) => {
       try {
-        const html = await getHtml();
-        if (!html) throw new Error('HTML export returned no content');
+        const rawHtml = await getHtml();
+        if (!rawHtml) throw new Error('HTML export returned no content');
+        const html = await formatAo3Html(rawHtml);
 
         let copied = false;
         try {

--- a/package/styles/editor.css
+++ b/package/styles/editor.css
@@ -880,10 +880,7 @@
   max-width: calc(100% - 1.5rem);
 }
 
-.ProseMirror
-  li
-  > ol
-  > li:has(> p[style*='text-align: right'])::before {
+.ProseMirror li > ol > li:has(> p[style*='text-align: right'])::before {
   position: static;
 }
 
@@ -1664,22 +1661,6 @@ ul[data-type='taskList'] li[data-checked='true'] > div > p > span {
       top: 0;
       left: 0;
     }
-  }
-}
-
-@media screen and (-webkit-min-device-pixel-ratio: 0) {
-  select,
-  textarea,
-  input {
-    font-size: 16px !important;
-  }
-}
-
-@media screen and (min-width: 768px) {
-  select,
-  textarea,
-  input {
-    font-size: 14px !important;
   }
 }
 

--- a/package/utils/format-ao3-html.test.ts
+++ b/package/utils/format-ao3-html.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { formatAo3Html } from './format-ao3-html';
+
+describe('formatAo3Html', () => {
+  it('strips class, id, style and data attributes', async () => {
+    const html = await formatAo3Html(
+      '<h1 class="select-text" id="abc" style="line-height: 138%;">Chapter</h1>' +
+        '<pre data-language="plaintext"><code class="language-plaintext">x</code></pre>',
+    );
+
+    expect(html).toBe('<h1>Chapter</h1>\n<pre><code>x</code></pre>');
+  });
+
+  it('keeps links and images intact', async () => {
+    const html = await formatAo3Html(
+      '<p><a class="custom-text-link" href="https://x.y">link</a></p>' +
+        '<img class="w-full" src="data:image/png;base64,AAAA" alt="Cover" width="320" height="200">',
+    );
+
+    expect(html).toBe(
+      '<p><a href="https://x.y">link</a></p>\n' +
+        '<img src="data:image/png;base64,AAAA" alt="Cover" width="320" height="200" />',
+    );
+  });
+
+  it('drops aria attributes and Mermaid SVG output', async () => {
+    const html = await formatAo3Html(
+      '<p aria-label="x">text</p><svg viewBox="0 0 1 1"><g><text>Label</text></g></svg>',
+    );
+
+    expect(html).toBe('<p>text</p>');
+  });
+
+  it('unwraps spans that carried only styling', async () => {
+    const html = await formatAo3Html(
+      '<p>a <span style="color: red">red</span> <strong class="x">b</strong></p>',
+    );
+
+    expect(html).toBe('<p>a red <strong>b</strong></p>');
+  });
+
+  it('puts each block on its own line without wrapping paragraph text', async () => {
+    const longText = 'lorem ipsum dolor sit amet '.repeat(12).trim();
+    const html = await formatAo3Html(
+      `<p>${longText}</p><ul><li><p>one</p></li></ul><blockquote><p>q</p></blockquote>`,
+    );
+
+    expect(html.split('\n')).toEqual([
+      `<p>${longText}</p>`,
+      '<ul>',
+      '  <li><p>one</p></li>',
+      '</ul>',
+      '<blockquote><p>q</p></blockquote>',
+    ]);
+  });
+});

--- a/package/utils/format-ao3-html.ts
+++ b/package/utils/format-ao3-html.ts
@@ -1,0 +1,36 @@
+import DOMPurify from 'dompurify';
+import prettier from 'prettier/standalone';
+import parserHtml from 'prettier/plugins/html';
+
+const KEPT_ATTRS = ['href', 'src', 'alt', 'width', 'height'];
+
+// AO3 drops class/id/style, data-*/aria-* and <svg> wholesale, so they only add
+// noise to the pasted markup. Spans left without attributes carry nothing either.
+const stripPresentationAttrs = (html: string): string => {
+  const body = DOMPurify.sanitize(html, {
+    ALLOWED_ATTR: KEPT_ATTRS,
+    ALLOW_DATA_ATTR: false,
+    ALLOW_ARIA_ATTR: false,
+    FORBID_TAGS: ['svg'],
+    RETURN_DOM_FRAGMENT: true,
+  });
+  body.querySelectorAll('span').forEach((span) => {
+    if (span.attributes.length === 0) span.replaceWith(...span.childNodes);
+  });
+  const holder = document.createElement('div');
+  holder.append(body);
+  return holder.innerHTML;
+};
+
+// Unbounded printWidth keeps each block's text on one line: AO3 turns line
+// breaks inside a paragraph into <br>, so only block boundaries may wrap.
+export const formatAo3Html = async (html: string): Promise<string> => {
+  const formatted = await prettier.format(stripPresentationAttrs(html), {
+    parser: 'html',
+    plugins: [parserHtml],
+    printWidth: Number.MAX_SAFE_INTEGER,
+    tabWidth: 2,
+    useTabs: false,
+  });
+  return formatted.trim();
+};


### PR DESCRIPTION
Strips `class`, `id`, `style`, `data-*` and `aria-*` attributes (and Mermaid `<svg>` output) from the "Copy HTML" (AO3) export, and pretty-prints the result so each block sits on its own line. Paragraph text is never wrapped, since AO3 turns newlines inside a paragraph into `<br>`. `href`, `src`, `alt`, `width` and `height` are kept.

The strip runs as a post-processor inside `copyAo3Html` rather than as an option on the shared sanitizer, so the `.html` file download keeps its `style` attributes for paragraph spacing.

Linear: https://linear.app/fileverse/issue/TEC-2958/strip-class-style-and-id-from-copy-as-html
