### PR TITLE
feat(sync-local): negotiate the collab wire format and seal with XChaCha (TEC-2936)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -42,11 +42,14 @@ export type {
   CollabError,
   CollabErrorCode,
   CollabStatus,
+  WireFormat,
+  WireTelemetryEvent,
 } from './package/sync-local/types';
 export {
   encryptForRoomKey,
   decryptForRoomKey,
 } from './package/sync-local/crypto/room-key';
+export { WIRE_TAG, isXChaChaCipher } from './package/sync-local/crypto';
 export {
   fetchSessionState,
   seedSession,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "4.8.16",
+  "version": "4.8.17-xchacha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "4.8.16",
+      "version": "4.8.17-xchacha.0",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -918,6 +918,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "aix"
@@ -933,6 +934,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -948,6 +950,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -963,6 +966,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -978,6 +982,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -993,6 +998,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -1008,6 +1014,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -1023,6 +1030,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -1038,6 +1046,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1053,6 +1062,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1068,6 +1078,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1083,6 +1094,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1098,6 +1110,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1113,6 +1126,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1128,6 +1142,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1143,6 +1158,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1158,6 +1174,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1173,6 +1190,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -1188,6 +1206,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -1203,6 +1222,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "sunos"
@@ -1218,6 +1238,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1233,6 +1254,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1248,6 +1270,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -3565,6 +3588,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -3577,6 +3601,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -3589,6 +3614,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -3601,6 +3627,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -3613,6 +3640,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -3625,6 +3653,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -3637,6 +3666,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3649,6 +3679,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3661,6 +3692,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3673,6 +3705,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3685,6 +3718,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3697,6 +3731,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3709,6 +3744,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3721,6 +3757,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3733,6 +3770,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3745,6 +3783,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3757,6 +3796,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3769,6 +3809,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "openharmony"
@@ -3781,6 +3822,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -3793,6 +3835,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -3805,6 +3848,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -3817,6 +3861,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "4.8.16",
+  "version": "4.8.17-xchacha.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/fileverse/fileverse-ddocs.git"

--- a/package/sync-local/SyncManager.ts
+++ b/package/sync-local/SyncManager.ts
@@ -4,11 +4,12 @@ import { fromUint8Array, toUint8Array } from 'js-base64';
 import { Awareness, removeAwarenessStates } from 'y-protocols/awareness.js';
 
 import { SocketClient } from './socketClient';
-import { crypto as cryptoUtils } from './crypto';
+import { crypto as cryptoUtils, isXChaChaCipher } from './crypto';
 import { createAwarenessUpdateHandler } from './utils/createAwarenessUpdateHandler';
 import {
   advanceFloor,
   computeLocalOnlyUpdate,
+  floorEligibleSeqs,
   shouldAuthorSnapshot,
 } from './floor';
 import {
@@ -22,6 +23,8 @@ import {
   CollabContext,
   CollabError,
   ServerErrorCode,
+  WireFormat,
+  WireTelemetryEvent,
 } from './types';
 import {
   transition,
@@ -45,6 +48,10 @@ interface HydrationWalk {
   merged: Uint8Array | null;
   pages: number;
   tailRows: number;
+  incomplete: boolean;
+  snapshotFormat: WireFormat | null;
+  eciesRows: number;
+  xchachaRows: number;
 }
 
 function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
@@ -103,10 +110,57 @@ export class SyncManager {
   private isProcessing = false;
   private syncId = 0;
   private floor = 0;
+  // Set when a catch-up read skipped a row it could not decrypt. While set, the floor is
+  // pinned below that row, no snapshot is authored and no local-only diff is broadcast.
+  // Cleared by the next miss-free catch-up read.
+  private hydrationIncomplete = false;
+  // Announced write format for the current room; every outbound seal goes through
+  // encryptForWire so a ratchet applies to the next batch without any other change.
+  private wireFormat: WireFormat = 'ecies';
+  private lastReportedWriteFormat: WireFormat | null = null;
+
+  getWireFormat(): WireFormat {
+    return this.wireFormat;
+  }
+
+  private encryptForWire(bytes: Uint8Array): string {
+    const sealed = cryptoUtils.encryptData(
+      this.roomKeyBytes!,
+      bytes,
+      this.wireFormat,
+    );
+    if (this.lastReportedWriteFormat !== this.wireFormat) {
+      this.lastReportedWriteFormat = this.wireFormat;
+      this.emitWireTelemetry({
+        type: 'write',
+        format: this.wireFormat,
+      });
+    }
+    return sealed;
+  }
+
+  private emitWireTelemetry(event: WireTelemetryEvent): void {
+    try {
+      this.callbacksRef?.onWireTelemetry?.(event);
+    } catch (err) {
+      console.error('SyncManager: onWireTelemetry callback threw', err);
+    }
+  }
+
+  private setWireFormat(format: WireFormat): void {
+    if (format === this.wireFormat) return;
+    this.wireFormat = format;
+    try {
+      this.callbacksRef?.onWireFormat?.(format);
+    } catch (err) {
+      console.error('SyncManager: onWireFormat callback threw', err);
+    }
+  }
+
   private updatesSinceSnapshot = 0;
   private isAuthoringSnapshot = false;
   private readonly SNAPSHOT_THRESHOLD = 100;
-  private tailCompactTimer: ReturnType<typeof setTimeout> | null = null;
+  private deferredSnapshotTimer: ReturnType<typeof setTimeout> | null = null;
   // Gap catch-up (rotation room-migration skew / missed broadcasts): see runGapCatchUp.
   private gapCatchUpTimer: ReturnType<typeof setTimeout> | null = null;
   private gapCatchUpInFlight = false;
@@ -279,7 +333,16 @@ export class SyncManager {
       onRotationPrepare: config.onRotationPrepare,
       actorHandle: config.actorHandle,
       joinOnly: config.joinOnly,
-      onHandshakeData: this.callbacksRef?.onHandshakeData,
+      onHandshakeData: (payload) => {
+        if (payload.data?.statusCode === 200) {
+          this.setWireFormat(payload.wireFormat);
+          this.emitWireTelemetry({
+            type: 'announced',
+            format: payload.wireFormat,
+          });
+        }
+        this.callbacksRef?.onHandshakeData?.(payload);
+      },
       roomInfo: config.roomInfo,
       onEpochAvailable: async (data: { epoch: number; payload: string }) => {
         try {
@@ -490,6 +553,7 @@ export class SyncManager {
           this._awareness,
           this.socketClient,
           this.roomKey,
+          () => this.wireFormat,
         );
         this._awareness.on('update', handler);
         this._awarenessUpdateHandler = handler;
@@ -653,10 +717,7 @@ export class SyncManager {
 
     const updates = this.updateQueue;
     this.updateQueue = [];
-    const encrypted = cryptoUtils.encryptData(
-      this.roomKeyBytes!,
-      Y.mergeUpdates(updates),
-    );
+    const encrypted = this.encryptForWire(Y.mergeUpdates(updates));
     try {
       // Bounded by the socket client's own emit timeout; we await the ACK so a graceful
       // unmount/route-change does not drop the last batch (the pre-existing bug).
@@ -688,7 +749,7 @@ export class SyncManager {
     this.updateQueue = [];
 
     const merged = Y.mergeUpdates(updates);
-    const encrypted = cryptoUtils.encryptData(this.roomKeyBytes!, merged);
+    const encrypted = this.encryptForWire(merged);
 
     void this.sendUpdateBatchAttempt(updates, encrypted);
   }
@@ -731,10 +792,7 @@ export class SyncManager {
             // that completed elsewhere (e.g. a joined healingPromise) while this send was
             // in flight; resending it would land old-key ciphertext in the new session's
             // durable log, undecryptable to fresh joiners.
-            const freshEncrypted = cryptoUtils.encryptData(
-              this.roomKeyBytes!,
-              Y.mergeUpdates(updates),
-            );
+            const freshEncrypted = this.encryptForWire(Y.mergeUpdates(updates));
             await this.sendUpdateBatchAttempt(updates, freshEncrypted);
             return;
           }
@@ -901,7 +959,7 @@ export class SyncManager {
   buildPendingBeaconPayload(): string | null {
     if (this.updateQueue.length === 0 || !this.roomKeyBytes) return null;
     const merged = Y.mergeUpdates(this.updateQueue);
-    return cryptoUtils.encryptData(this.roomKeyBytes, merged);
+    return this.encryptForWire(merged);
   }
 
   fireBeacon(): void {
@@ -1063,6 +1121,22 @@ export class SyncManager {
             }
           },
           onHandShakeError: (e, statusCode, errorCode) => {
+            // The room is locked to a wire format this bundle predates. Terminal for every
+            // role: no reconnect, the host prompts a reload.
+            if (errorCode === ServerErrorCode.WIRE_FORMAT_UNSUPPORTED) {
+              if (!settled) {
+                settled = true;
+                resolve();
+              }
+              this.emitWireTelemetry({ type: 'refused' });
+              this.socketClient?.disconnect();
+              this.resetInternalState();
+              this.send({
+                type: 'SESSION_TERMINATED',
+                reason: 'WIRE_FORMAT_UNSUPPORTED',
+              });
+              return;
+            }
             // Join-only (workspace member) connections degrade quietly: every handshake
             // rejection is a terminal no-session outcome, never an error surface. The
             // distinct ROOM_NOT_ESTABLISHED reason lets the host render read-only until
@@ -1179,6 +1253,9 @@ export class SyncManager {
           onTitleUpdate: (encryptedTitle) => {
             this.callbacksRef?.onTitleUpdate?.(encryptedTitle);
           },
+          onWireFormat: (data) => {
+            this.setWireFormat(data.wireFormat);
+          },
           onSessionTerminated: async () => {
             // A live-socket push of this event during a NORMAL rotation is reachable two
             // ways: a peer that PREPARE'd, blipped, and re-authed into the still-draining
@@ -1261,16 +1338,17 @@ export class SyncManager {
     }
   }
 
-  private decodeInto(target: Uint8Array[], encrypted: string): void {
+  private decodeInto(target: Uint8Array[], encrypted: string): boolean {
     const decrypted = this.tryDecrypt(encrypted);
     if (!decrypted) {
       // Undecryptable rows (e.g. a guessed-documentId injection, or a genuine rotation
-      // miss) are skipped, not fatal.
+      // miss) are skipped, not fatal. The caller pins the floor below this row.
       console.warn('SyncManager: failed to decrypt hydration row, skipping');
       void this.onDecryptMiss();
-      return;
+      return false;
     }
     target.push(decrypted);
+    return true;
   }
 
   // Pull the server's snapshot + seq-tail from the current floor, apply it to the Y.Doc,
@@ -1288,47 +1366,98 @@ export class SyncManager {
       (this.isReady && this.syncId === syncId);
     let sinceSeq: number | undefined = this.floor > 0 ? this.floor : undefined;
     let appliedTail = false;
+    // A miss pins the floor for the rest of this walk only. Every walk starts clean and
+    // re-reads from the pinned floor, so a clean walk proves the row decrypts now and
+    // clears hydrationIncomplete at the end.
+    let walkIncomplete = false;
 
-    for (;;) {
-      const res = await this.socketClient?.fetchHydrationRange(sinceSeq);
-      if (!syncStillCurrent()) return appliedTail;
-      const d = res?.data;
-      if (!d) return appliedTail;
-
-      const updates: Uint8Array[] = [];
-      const pageSeqs: number[] = [];
-      for (const row of d.history) {
-        this.decodeInto(updates, row.data);
-        if (row.updateType !== 'snapshot' && typeof row.seq === 'number') {
-          pageSeqs.push(row.seq);
+    try {
+      for (;;) {
+        const res = await this.socketClient?.fetchHydrationRange(sinceSeq);
+        if (!syncStillCurrent()) {
+          if (walkIncomplete) {
+            this.hydrationIncomplete = true;
+            if (walk) walk.incomplete = true;
+          }
+          return appliedTail;
         }
-      }
-      if (walk) {
-        walk.pages += 1;
-        walk.tailRows += pageSeqs.length;
-      }
-      if (updates.length) {
-        const pageMerged = Y.mergeUpdates(updates);
-        Y.applyUpdate(this.ydoc, pageMerged, 'self');
-        appliedTail = appliedTail || pageSeqs.length > 0;
+        const d = res?.data;
+        if (!d) {
+          if (walkIncomplete) {
+            this.hydrationIncomplete = true;
+            if (walk) walk.incomplete = true;
+          }
+          return appliedTail;
+        }
+
+        const updates: Uint8Array[] = [];
+        const rowsForFloor: Array<{
+          seq: number | null;
+          isTail: boolean;
+          decrypted: boolean;
+        }> = [];
+        let snapshotDecrypted = true;
+        for (const row of d.history) {
+          const decrypted = this.decodeInto(updates, row.data);
+          const isTail = row.updateType !== 'snapshot';
+          if (!isTail && !decrypted) snapshotDecrypted = false;
+          rowsForFloor.push({
+            seq: typeof row.seq === 'number' ? row.seq : null,
+            isTail,
+            decrypted,
+          });
+          if (walk && decrypted) {
+            if (isXChaChaCipher(row.data)) walk.xchachaRows += 1;
+            else walk.eciesRows += 1;
+          }
+        }
+        const eligible = floorEligibleSeqs(rowsForFloor, walkIncomplete);
+        walkIncomplete = eligible.incomplete;
+        const pageSeqs = eligible.seqs;
         if (walk) {
-          walk.merged = walk.merged
-            ? Y.mergeUpdates([walk.merged, pageMerged])
-            : pageMerged;
+          walk.pages += 1;
+          walk.tailRows += rowsForFloor.filter((r) => r.isTail).length;
+          if (d.snapshot && walk.snapshotFormat === null) {
+            walk.snapshotFormat = isXChaChaCipher(d.snapshot.data)
+              ? 'xchacha'
+              : 'ecies';
+          }
         }
-      }
+        if (updates.length) {
+          const pageMerged = Y.mergeUpdates(updates);
+          Y.applyUpdate(this.ydoc, pageMerged, 'self');
+          appliedTail =
+            appliedTail || rowsForFloor.some((r) => r.isTail && r.seq !== null);
+          if (walk) {
+            walk.merged = walk.merged
+              ? Y.mergeUpdates([walk.merged, pageMerged])
+              : pageMerged;
+          }
+        }
 
-      const snapFloor =
-        d.snapshot && typeof d.snapshot.floorSeq === 'number'
-          ? d.snapshot.floorSeq
-          : 0;
-      this.floor = advanceFloor(Math.max(this.floor, snapFloor), pageSeqs);
+        const snapFloor =
+          d.snapshot &&
+          typeof d.snapshot.floorSeq === 'number' &&
+          snapshotDecrypted &&
+          !walkIncomplete
+            ? d.snapshot.floorSeq
+            : 0;
+        this.floor = advanceFloor(Math.max(this.floor, snapFloor), pageSeqs);
 
-      if (d.hasMore && typeof d.nextSeq === 'number') {
-        sinceSeq = d.nextSeq;
-        continue;
+        if (d.hasMore && typeof d.nextSeq === 'number') {
+          sinceSeq = d.nextSeq;
+          continue;
+        }
+        this.hydrationIncomplete = walkIncomplete;
+        if (walk) walk.incomplete = walkIncomplete;
+        return appliedTail;
       }
-      return appliedTail;
+    } catch (err) {
+      if (walkIncomplete) {
+        this.hydrationIncomplete = true;
+        if (walk) walk.incomplete = true;
+      }
+      throw err;
     }
   }
 
@@ -1340,6 +1469,7 @@ export class SyncManager {
   private async authorSnapshot(
     publishedMarker: string | null,
     syncId: number,
+    opts?: { allowEmptyFloor?: boolean },
   ): Promise<void> {
     if (this.joinOnly || !this.isConnected) return;
     if (this.isAuthoringSnapshot) return;
@@ -1349,12 +1479,20 @@ export class SyncManager {
         this.isCurrentSyncAttempt(syncId) || this.isReady;
 
       await this.catchUpFloor(syncId);
-      if (!syncStillCurrent() || this.floor <= 0) return;
+      // Never stamp a floor above content this client never applied.
+      if (this.hydrationIncomplete) {
+        // Cannot author over a row this client could not read; retry at the normal cadence
+        // rather than on every send.
+        this.updatesSinceSnapshot = 0;
+        return;
+      }
+      if (!syncStillCurrent()) return;
+      // A floor of 0 after a clean walk is an empty log or a seeded snapshot-only log
+      // (floorSeq 0, no tail). The cadence path never authors there; the wire-format
+      // re-author must, or a seeded document keeps its ECIES snapshot until its first edit.
+      if (this.floor <= 0 && !opts?.allowEmptyFloor) return;
 
-      const data = cryptoUtils.encryptData(
-        this.roomKeyBytes!,
-        Y.encodeStateAsUpdate(this.ydoc),
-      );
+      const data = this.encryptForWire(Y.encodeStateAsUpdate(this.ydoc));
       const res = await this.socketClient?.sendSnapshot({
         data,
         floorSeq: this.floor,
@@ -1376,7 +1514,15 @@ export class SyncManager {
     // local edits ride the update queue there, so no post-sync broadcast is needed.
     const fullWalk = this.floor === 0;
     const hadLocalState = this.ydoc.store.clients.size > 0;
-    const walk: HydrationWalk = { merged: null, pages: 0, tailRows: 0 };
+    const walk: HydrationWalk = {
+      merged: null,
+      pages: 0,
+      tailRows: 0,
+      incomplete: false,
+      snapshotFormat: null,
+      eciesRows: 0,
+      xchachaRows: 0,
+    };
 
     await this.withRetry(async () => {
       const appliedTail = await this.catchUpFloor(syncId, walk);
@@ -1386,7 +1532,14 @@ export class SyncManager {
         this.send({ type: 'SET_UNMERGED_UPDATES', hasUpdates: true });
       }
 
+      // The diff is taken against the state vector of what was merged, so it carries the
+      // client's own unmerged content; ops a missed row also held are re-sent idempotently.
+      // Suppressing it would strand offline-authored content while the floor is pinned.
       if (!fullWalk || !hadLocalState) return;
+      // With nothing merged at all (no page ever read, or an unreadable snapshot and no
+      // readable row) the diff would be the whole local doc; that is the full-state row
+      // per join, not a diff. An empty log still seeds: pages is 1 and incomplete false.
+      if (walk.pages === 0 || (walk.incomplete && walk.merged === null)) return;
       // Broadcast ONLY what the log provably lacks (e.g. offline/IndexedDB edits, tab
       // metadata minted before connect) — never the full state: a full-state row per join
       // grew the durable log by one document copy per visit.
@@ -1396,28 +1549,67 @@ export class SyncManager {
       await this.broadcastLocalContents(fromUint8Array(diff), syncId);
     }, 'hydrate');
 
-    this.maybeCompactTail(walk);
+    // Only a completed first walk describes the log: a walk that never read a page (the
+    // session terminated during connect) or a reconnect walk (no snapshot is served above
+    // the floor) would report an empty log.
+    if (fullWalk && walk.pages > 0 && syncStillCurrent()) {
+      this.emitWireTelemetry({
+        type: 'hydrate',
+        eciesRows: walk.eciesRows,
+        xchachaRows: walk.xchachaRows,
+        snapshotFormat: walk.snapshotFormat,
+        incomplete: walk.incomplete,
+      });
+    }
+    // A room locked to XChaCha whose newest snapshot is still ECIES: author one so the
+    // live hydration path stops depending on ECIES rows. Once per open, never on a
+    // reconnect walk (no snapshot is served above a pinned floor), never while incomplete.
+    // Deferred with the compaction jitter so simultaneous joiners do not all write the
+    // same full-state snapshot in the same second; a compaction authors a snapshot of its
+    // own, which converts the format as a side effect, so a document needing both gets
+    // one write.
+    const reauthor =
+      fullWalk &&
+      this.wireFormat === 'xchacha' &&
+      walk.snapshotFormat === 'ecies' &&
+      !walk.incomplete &&
+      !this.joinOnly &&
+      syncStillCurrent();
+    if (!this.maybeCompactTail(walk) && reauthor) {
+      this.scheduleDeferredSnapshot('wire-format snapshot re-author', {
+        allowEmptyFloor: true,
+      });
+    }
   }
 
   // A tail that took multiple pages (or hundreds of rows) makes every future open pay
-  // serial round-trips — whoever hydrated it and can write collapses it into one
-  // snapshot. Jitter spreads simultaneous joiners; a lost race is harmless (snapshots
-  // are keep-latest and floors monotone).
-  private maybeCompactTail(walk: HydrationWalk): void {
+  // serial round-trips: whoever hydrated it and can write collapses it into one
+  // snapshot. Returns whether a compaction was scheduled.
+  private maybeCompactTail(walk: HydrationWalk): boolean {
     if (
       walk.pages < this.TAIL_COMPACT_PAGES &&
       walk.tailRows < this.TAIL_COMPACT_ROWS
     ) {
-      return;
+      return false;
     }
-    if (this.joinOnly) return;
-    if (this.tailCompactTimer) clearTimeout(this.tailCompactTimer);
-    this.tailCompactTimer = setTimeout(
+    if (this.joinOnly) return false;
+    this.scheduleDeferredSnapshot('tail compaction');
+    return true;
+  }
+
+  // One timer for every deferred author: the jitter spreads simultaneous joiners, and a
+  // lost race is harmless (snapshots are keep-latest and floors monotone).
+  private scheduleDeferredSnapshot(
+    label: string,
+    opts?: { allowEmptyFloor?: boolean },
+  ): void {
+    if (this.deferredSnapshotTimer) clearTimeout(this.deferredSnapshotTimer);
+    this.deferredSnapshotTimer = setTimeout(
       () => {
-        this.tailCompactTimer = null;
+        this.deferredSnapshotTimer = null;
         if (!this.isConnected) return;
-        this.authorSnapshot(null, this.syncId).catch((err) => {
-          console.error('SyncManager: tail compaction failed', err);
+        this.authorSnapshot(null, this.syncId, opts).catch((err) => {
+          console.error(`SyncManager: ${label} failed`, err);
         });
       },
       1000 + Math.floor(Math.random() * 4000),
@@ -1432,6 +1624,7 @@ export class SyncManager {
         awareness,
         this.socketClient,
         this.roomKey,
+        () => this.wireFormat,
       );
       awareness.on('update', handler);
       this.socketClient.registerAwareness(awareness);
@@ -1461,10 +1654,7 @@ export class SyncManager {
 
     if (!unbroadcastedUpdate) return;
 
-    const updateToSend = cryptoUtils.encryptData(
-      this.roomKeyBytes!,
-      toUint8Array(unbroadcastedUpdate),
-    );
+    const updateToSend = this.encryptForWire(toUint8Array(unbroadcastedUpdate));
     if (!syncStillCurrent()) return;
 
     const response = await this.socketClient?.sendUpdate({
@@ -1537,7 +1727,7 @@ export class SyncManager {
     const nextUpdate = Y.mergeUpdates(this.updateQueue);
     // Re-encrypted in place on a 'current-key-ok' retry below — the plaintext (`nextUpdate`)
     // doesn't change across a retry, but the key it's encrypted under might.
-    let updateToSend = cryptoUtils.encryptData(this.roomKeyBytes!, nextUpdate);
+    let updateToSend = this.encryptForWire(nextUpdate);
 
     let lastError: Error | null = null;
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
@@ -1574,10 +1764,7 @@ export class SyncManager {
               // Re-encrypt first: `updateToSend` may predate a rekey that completed
               // elsewhere (e.g. a joined healingPromise) since this attempt started.
               this.staleAckRetries += 1;
-              updateToSend = cryptoUtils.encryptData(
-                this.roomKeyBytes!,
-                nextUpdate,
-              );
+              updateToSend = this.encryptForWire(nextUpdate);
               continue;
             }
             this.surfaceSessionTerminated('SESSION_TERMINATED');
@@ -1785,9 +1972,9 @@ export class SyncManager {
       clearTimeout(this.mirrorIdleTimer);
       this.mirrorIdleTimer = null;
     }
-    if (this.tailCompactTimer) {
-      clearTimeout(this.tailCompactTimer);
-      this.tailCompactTimer = null;
+    if (this.deferredSnapshotTimer) {
+      clearTimeout(this.deferredSnapshotTimer);
+      this.deferredSnapshotTimer = null;
     }
     if (this.gapCatchUpTimer) {
       clearTimeout(this.gapCatchUpTimer);
@@ -1803,6 +1990,9 @@ export class SyncManager {
     this.roomKeyBytes = null;
     this.isOwner = false;
     this.floor = 0;
+    this.hydrationIncomplete = false;
+    this.wireFormat = 'ecies';
+    this.lastReportedWriteFormat = null;
     this.updatesSinceSnapshot = 0;
     this.isAuthoringSnapshot = false;
     // Rotation state must not bleed into the next session on manager reuse — e.g. a

--- a/package/sync-local/crypto/index.ts
+++ b/package/sync-local/crypto/index.ts
@@ -3,19 +3,77 @@ import {
   eciesDecrypt,
   eciesEncrypt,
 } from '@fileverse/crypto/ecies';
+import { deriveHKDFKey } from '@fileverse/crypto/kdf';
 import { generateRandomBytes } from '@fileverse/crypto/utils';
 import { secp256k1 } from '@noble/curves/secp256k1';
+import { xchacha20poly1305 } from '@noble/ciphers/chacha';
+import { fromUint8Array, toUint8Array } from 'js-base64';
+import type { WireFormat } from '../types';
+
+// Collab wire cipher. `ecies` is byte-identical to the historical shim; `xchacha` seals
+// under an HKDF subkey of the roomKey and tags the string so decrypt can route without a
+// flag.
+export const WIRE_TAG = 'FVXC1';
+const SEPARATOR = '__n__';
+const WIRE_PREFIX = WIRE_TAG + SEPARATOR;
+const WIRE_INFO = new TextEncoder().encode(
+  'FILEVERSE-COLLAB-WIRE-XCHACHA20POLY1305-FVXC1',
+);
+const NONCE_LEN = 24;
+const MEMO_CAP = 8;
+
+// Subkey memo keyed by the base64 roomKey: one derivation per socket, one more per rekey.
+const wireKeys = new Map<string, Uint8Array>();
+
+const wireKeyFor = (roomKey: Uint8Array): Uint8Array => {
+  const id = fromUint8Array(roomKey);
+  const hit = wireKeys.get(id);
+  if (hit) return hit;
+  const derived = deriveHKDFKey(roomKey, new Uint8Array(0), WIRE_INFO);
+  if (wireKeys.size >= MEMO_CAP) {
+    const oldest = wireKeys.keys().next().value;
+    if (oldest !== undefined) wireKeys.delete(oldest);
+  }
+  wireKeys.set(id, derived);
+  return derived;
+};
+
+export const isXChaChaCipher = (message: unknown): message is string =>
+  typeof message === 'string' && message.startsWith(WIRE_PREFIX);
 
 export const crypto = {
   generateKeyPair: () => {
     return generateECKeyPair();
   },
-  encryptData: (key: Uint8Array, message: Uint8Array) => {
+  encryptData: (
+    key: Uint8Array,
+    message: Uint8Array,
+    format: WireFormat = 'ecies',
+  ): string => {
+    if (format === 'xchacha') {
+      const nonce = generateRandomBytes(NONCE_LEN);
+      const sealed = xchacha20poly1305(wireKeyFor(key), nonce).encrypt(message);
+      return (
+        WIRE_PREFIX + fromUint8Array(nonce) + SEPARATOR + fromUint8Array(sealed)
+      );
+    }
     const pubKey = secp256k1.getPublicKey(key);
-
     return eciesEncrypt(pubKey, message, 'base64');
   },
-  decryptData: (key: Uint8Array, message: string) => {
+  decryptData: (key: Uint8Array, message: string): Uint8Array => {
+    if (isXChaChaCipher(message)) {
+      const parts = message.split(SEPARATOR);
+      if (parts.length !== 3 || !parts[1] || !parts[2]) {
+        throw new Error('Invalid FVXC1 wire format');
+      }
+      const nonce = toUint8Array(parts[1]);
+      if (nonce.length !== NONCE_LEN) {
+        throw new Error('Invalid FVXC1 nonce length');
+      }
+      return xchacha20poly1305(wireKeyFor(key), nonce).decrypt(
+        toUint8Array(parts[2]),
+      );
+    }
     return eciesDecrypt(key, message);
   },
   generateRandomBytes,

--- a/package/sync-local/crypto/room-key.test.ts
+++ b/package/sync-local/crypto/room-key.test.ts
@@ -1,15 +1,102 @@
 import { describe, it, expect } from 'vitest';
 import { fromUint8Array } from 'js-base64';
 import { encryptForRoomKey, decryptForRoomKey } from './room-key';
+import { WIRE_TAG, isXChaChaCipher } from './index';
 
-describe('roomKey outer wrap', () => {
+const roomKey = fromUint8Array(new Uint8Array(32).fill(7), true);
+const otherKey = fromUint8Array(new Uint8Array(32).fill(9), true);
+const msg = new TextEncoder().encode('hello-rotation');
+const text = (u: Uint8Array) => new TextDecoder().decode(u);
+
+describe('roomKey wrap, ecies (default)', () => {
   it('round-trips bytes under a base64 roomKey', () => {
-    const roomKey = fromUint8Array(new Uint8Array(32).fill(7), true);
-    const msg = new TextEncoder().encode('hello-rotation');
     const ct = encryptForRoomKey(roomKey, msg);
     expect(typeof ct).toBe('string');
-    expect(new TextDecoder().decode(decryptForRoomKey(roomKey, ct))).toBe(
-      'hello-rotation',
-    );
+    expect(text(decryptForRoomKey(roomKey, ct))).toBe('hello-rotation');
+  });
+
+  it('ecies strings start with A and are not detected as xchacha', () => {
+    const ct = encryptForRoomKey(roomKey, msg);
+    expect(ct.startsWith('A')).toBe(true);
+    expect(isXChaChaCipher(ct)).toBe(false);
+  });
+});
+
+describe('roomKey wrap, xchacha', () => {
+  it('round-trips and carries the FVXC1 tag', () => {
+    const ct = encryptForRoomKey(roomKey, msg, 'xchacha');
+    expect(ct.startsWith(`${WIRE_TAG}__n__`)).toBe(true);
+    expect(ct.split('__n__')).toHaveLength(3);
+    expect(isXChaChaCipher(ct)).toBe(true);
+    expect(text(decryptForRoomKey(roomKey, ct))).toBe('hello-rotation');
+  });
+
+  it('uses a fresh nonce per call', () => {
+    const a = encryptForRoomKey(roomKey, msg, 'xchacha');
+    const b = encryptForRoomKey(roomKey, msg, 'xchacha');
+    expect(a).not.toBe(b);
+    expect(a.split('__n__')[1]).not.toBe(b.split('__n__')[1]);
+  });
+
+  it('rejects a tampered ciphertext', () => {
+    const ct = encryptForRoomKey(roomKey, msg, 'xchacha');
+    const parts = ct.split('__n__');
+    const body = parts[2];
+    const flipped =
+      body.slice(0, 4) + (body[4] === 'A' ? 'B' : 'A') + body.slice(5);
+    expect(() =>
+      decryptForRoomKey(roomKey, [parts[0], parts[1], flipped].join('__n__')),
+    ).toThrow();
+  });
+
+  it('rejects the wrong key', () => {
+    const ct = encryptForRoomKey(roomKey, msg, 'xchacha');
+    expect(() => decryptForRoomKey(otherKey, ct)).toThrow();
+  });
+
+  it('rejects a malformed FVXC1 string', () => {
+    expect(() => decryptForRoomKey(roomKey, `${WIRE_TAG}__n__abc`)).toThrow();
+  });
+
+  it('decrypt routes on the string alone, so a mixed log reads back', () => {
+    const e = encryptForRoomKey(roomKey, msg);
+    const x = encryptForRoomKey(roomKey, msg, 'xchacha');
+    expect(text(decryptForRoomKey(roomKey, e))).toBe('hello-rotation');
+    expect(text(decryptForRoomKey(roomKey, x))).toBe('hello-rotation');
+  });
+
+  it('decrypts a pinned FVXC1 vector', () => {
+    // Known-answer vector: roomKey = 32 bytes of 0x11, nonce = 24 bytes of 0x22,
+    // plaintext = utf8 "fileverse". Generated once with the shim's own primitives
+    // (deriveHKDFKey + xchacha20poly1305) and pinned here as a decrypt-only check.
+    const pinnedRoomKey = fromUint8Array(new Uint8Array(32).fill(0x11), true);
+    const vector =
+      'FVXC1__n__IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIi__n__OsiBUtWLlLepzg63yglbs4+QpaWJxkYvEQ==';
+    expect(text(decryptForRoomKey(pinnedRoomKey, vector))).toBe('fileverse');
+  });
+
+  it('rejects a wire string whose nonce is not 24 bytes', () => {
+    const ct = encryptForRoomKey(roomKey, msg, 'xchacha');
+    const parts = ct.split('__n__');
+    const shortNonce = fromUint8Array(new Uint8Array(23).fill(1));
+    expect(() =>
+      decryptForRoomKey(
+        roomKey,
+        [parts[0], shortNonce, parts[2]].join('__n__'),
+      ),
+    ).toThrow();
+  });
+
+  it('round-trips an empty message under xchacha', () => {
+    const ct = encryptForRoomKey(roomKey, new Uint8Array(0), 'xchacha');
+    expect(decryptForRoomKey(roomKey, ct).length).toBe(0);
+  });
+
+  it('isXChaChaCipher guards non-string input and is true for a fresh xchacha output', () => {
+    expect(isXChaChaCipher(undefined)).toBe(false);
+    expect(isXChaChaCipher(null)).toBe(false);
+    expect(isXChaChaCipher(42)).toBe(false);
+    const ct = encryptForRoomKey(roomKey, msg, 'xchacha');
+    expect(isXChaChaCipher(ct)).toBe(true);
   });
 });

--- a/package/sync-local/crypto/room-key.ts
+++ b/package/sync-local/crypto/room-key.ts
@@ -1,10 +1,15 @@
 import { toUint8Array } from 'js-base64';
 import { crypto } from './index';
+import type { WireFormat } from '../types';
 
-// Outer wrap of the rotation relay: the same ECIES the collab wire uses, keyed by a base64
-// roomKey string. Owner encrypts under the pre-rotation roomKey; members decrypt with it.
-export const encryptForRoomKey = (roomKey: string, bytes: Uint8Array): string =>
-  crypto.encryptData(toUint8Array(roomKey), bytes);
+// Outer wrap of the rotation relay: the same cipher the collab wire uses, keyed by a
+// base64 roomKey string. Owner encrypts under the pre-rotation roomKey in the format the
+// room announced; members decrypt with it (decrypt routes on the string).
+export const encryptForRoomKey = (
+  roomKey: string,
+  bytes: Uint8Array,
+  format: WireFormat = 'ecies',
+): string => crypto.encryptData(toUint8Array(roomKey), bytes, format);
 
 export const decryptForRoomKey = (
   roomKey: string,

--- a/package/sync-local/floor.test.ts
+++ b/package/sync-local/floor.test.ts
@@ -3,6 +3,7 @@ import * as Y from 'yjs';
 import {
   advanceFloor,
   computeLocalOnlyUpdate,
+  floorEligibleSeqs,
   shouldAuthorSnapshot,
 } from './floor';
 
@@ -123,5 +124,40 @@ describe('shouldAuthorSnapshot', () => {
         threshold: 100,
       }),
     ).toBe(false);
+  });
+});
+
+describe('floorEligibleSeqs', () => {
+  const ok = (seq: number) => ({ seq, isTail: true, decrypted: true });
+  const miss = (seq: number) => ({ seq, isTail: true, decrypted: false });
+  const snapshot = (decrypted: boolean) => ({
+    seq: null,
+    isTail: false,
+    decrypted,
+  });
+
+  it('returns every tail seq when everything decrypts', () => {
+    const r = floorEligibleSeqs([snapshot(true), ok(3), ok(4), ok(6)], false);
+    expect(r).toEqual({ seqs: [3, 4, 6], incomplete: false });
+  });
+
+  it('pins the floor below the first miss and flags incomplete', () => {
+    const r = floorEligibleSeqs([ok(3), ok(4), miss(5), ok(6)], false);
+    expect(r).toEqual({ seqs: [3, 4], incomplete: true });
+  });
+
+  it('stays pinned on later pages once incomplete', () => {
+    const r = floorEligibleSeqs([ok(9), ok(10)], true);
+    expect(r).toEqual({ seqs: [], incomplete: true });
+  });
+
+  it('a snapshot miss pins everything on that page', () => {
+    const r = floorEligibleSeqs([snapshot(false), ok(3), ok(4)], false);
+    expect(r).toEqual({ seqs: [], incomplete: true });
+  });
+
+  it('a decrypted snapshot contributes no seq of its own', () => {
+    const r = floorEligibleSeqs([snapshot(true)], false);
+    expect(r).toEqual({ seqs: [], incomplete: false });
   });
 });

--- a/package/sync-local/floor.ts
+++ b/package/sync-local/floor.ts
@@ -54,3 +54,20 @@ export function computeLocalOnlyUpdate(
   }
   return diff;
 }
+
+// Seqs that may advance the floor from one hydration page. A row that failed to decrypt
+// pins the floor below it for the rest of the walk, so a later snapshot can never stamp a
+// floorSeq above content this client never applied.
+export function floorEligibleSeqs(
+  rows: Array<{ seq: number | null; isTail: boolean; decrypted: boolean }>,
+  alreadyIncomplete: boolean,
+): { seqs: number[]; incomplete: boolean } {
+  const seqs: number[] = [];
+  let incomplete = alreadyIncomplete;
+  for (const row of rows) {
+    if (!row.decrypted) incomplete = true;
+    if (incomplete) continue;
+    if (row.isTail && typeof row.seq === 'number') seqs.push(row.seq);
+  }
+  return { seqs, incomplete };
+}

--- a/package/sync-local/session-tools.ts
+++ b/package/sync-local/session-tools.ts
@@ -145,6 +145,7 @@ export async function seedSession(args: {
     const data = cryptoUtils.encryptData(
       toUint8Array(args.newRoomKey),
       args.state,
+      client.getWireFormat(),
     );
     const res = await client.sendSnapshot({ data, floorSeq: 0 });
     if (!res?.status) {

--- a/package/sync-local/socketClient.ts
+++ b/package/sync-local/socketClient.ts
@@ -10,6 +10,7 @@ import {
   SnapshotResponse,
   IAuthArgs,
   AckResponse,
+  WireFormat,
 } from './types';
 import {
   assignSessionColors,
@@ -60,13 +61,21 @@ interface ISocketClientConfig {
   onCutover?: (data: { roomId: string; epoch: number }) => void | Promise<void>;
   actorHandle?: string;
   joinOnly?: boolean;
-  onHandshakeData?: (response: { data: AckResponse; roomKey: string }) => void;
+  onHandshakeData?: (response: {
+    data: AckResponse;
+    roomKey: string;
+    wireFormat: WireFormat;
+  }) => void;
   roomInfo?: {
     documentTitle: string;
     portalAddress: string;
     commentKey: string;
   };
 }
+
+const toWireFormat = (value: unknown): WireFormat =>
+  value === 'xchacha' ? 'xchacha' : 'ecies';
+
 export class SocketClient {
   private _socketUrl: string;
   private _restBase: string;
@@ -109,6 +118,12 @@ export class SocketClient {
   private actorHandle?: string;
   private joinOnly?: boolean;
   private roomKey: string;
+  // What the server announced for this room. ECIES until an ack or ratchet says otherwise.
+  private wireFormat: WireFormat = 'ecies';
+
+  getWireFormat(): WireFormat {
+    return this.wireFormat;
+  }
   private roomInfo?: {
     documentTitle: string;
     portalAddress: string;
@@ -599,12 +614,17 @@ export class SocketClient {
       collaborationToken: token,
       sessionDid: this.collaborationKeyPair?.did(),
       documentId: this.roomId,
+      wireFormats: ['ecies', 'xchacha'],
     };
 
+    // roomInfo is sealed in the last announced format: on a first auth that is ECIES
+    // even if this ack ratchets the room. Readers accept both; the owner's next auth
+    // rewrites it.
     if (this.roomInfo)
       args.roomInfo = crypto.encryptData(
         toUint8Array(this.roomKey),
         new TextEncoder().encode(JSON.stringify(this.roomInfo)),
+        this.wireFormat,
       );
 
     if (this.ownerKeyPair) args.ownerToken = await this.getOwnerToken();
@@ -634,10 +654,18 @@ export class SocketClient {
 
     const response = await this._emitWithAck('/auth', args);
 
+    // A lock is permanent, so a socket that already learned xchacha (an earlier ack, or a
+    // live ratchet that landed between this socket's join and its ack) never steps back to
+    // ECIES on a later ack.
+    if (response.statusCode === 200 && this.wireFormat !== 'xchacha') {
+      this.wireFormat = toWireFormat(response.data?.wireFormat);
+    }
+
     // Always notify consumer with handshake data (for room info, link copying, etc.)
     this._onHandshakeData?.({
       data: response,
       roomKey: this.roomKey,
+      wireFormat: this.wireFormat,
     });
 
     return response;
@@ -781,6 +809,18 @@ export class SocketClient {
         },
       );
 
+      this._socket.on(
+        '/document/wire_format' as any,
+        (data: { roomId: string; wireFormat: WireFormat }) => {
+          if (data?.roomId !== this.roomId) return;
+          this.wireFormat = toWireFormat(data.wireFormat);
+          config.onWireFormat?.({
+            roomId: data.roomId,
+            wireFormat: this.wireFormat,
+          });
+        },
+      );
+
       this._socket.on('/room/membership_change', (data) => {
         this._fetchRoomMembers()
           .then(() => this._recomputePresence())
@@ -906,6 +946,7 @@ export class SocketClient {
               const encryptedUpdate = crypto.encryptData(
                 toUint8Array(key),
                 update,
+                this.wireFormat,
               );
               this.broadcastAwareness(encryptedUpdate);
             }

--- a/package/sync-local/types/index.ts
+++ b/package/sync-local/types/index.ts
@@ -2,6 +2,23 @@
 import { Data, IDocCollabUsers } from '../../types';
 import * as Y from 'yjs';
 
+/** Collab wire cipher. `ecies` is the historical secp256k1 ECIES; `xchacha` is
+ *  XChaCha20-Poly1305 under an HKDF subkey of the roomKey (FVXC1). */
+export type WireFormat = 'ecies' | 'xchacha';
+
+/** Host telemetry for the wire migration; the package never imports a reporter. */
+export type WireTelemetryEvent =
+  | { type: 'announced'; format: WireFormat }
+  | { type: 'write'; format: WireFormat }
+  | {
+      type: 'hydrate';
+      eciesRows: number;
+      xchachaRows: number;
+      snapshotFormat: WireFormat | null;
+      incomplete: boolean;
+    }
+  | { type: 'refused' };
+
 // ─── Collaboration prop types ───
 
 /** Connection identity — changes to these trigger reconnect */
@@ -142,7 +159,14 @@ export interface CollabCallbacks {
   onStateChange?: (state: CollabState) => void;
   onError?: (error: CollabError) => void;
   onCollaboratorsChange?: (collaborators: IDocCollabUsers[]) => void;
-  onHandshakeData?: (data: { data: AckResponse; roomKey: string }) => void;
+  onHandshakeData?: (data: {
+    data: AckResponse;
+    roomKey: string;
+    wireFormat: WireFormat;
+  }) => void;
+  /** The write format the server announced for this room (auth ack or live ratchet). */
+  onWireFormat?: (format: WireFormat) => void;
+  onWireTelemetry?: (event: WireTelemetryEvent) => void;
   /** Live rename from the room owner; title is roomKey-encrypted. */
   onTitleUpdate?: (encryptedTitle: string | null) => void;
   /** Decrypt-miss self-heal: resolves the CURRENT-epoch roomKey (same resolution the host
@@ -194,6 +218,7 @@ export enum ServerErrorCode {
   JOIN_DISABLED = 'JOIN_DISABLED',
   EDIT_REVOKED = 'EDIT_REVOKED',
   ROOM_NOT_ESTABLISHED = 'ROOM_NOT_ESTABLISHED',
+  WIRE_FORMAT_UNSUPPORTED = 'WIRE_FORMAT_UNSUPPORTED',
 }
 
 export interface AckResponse<T = Record<string, any>> {
@@ -263,6 +288,7 @@ export interface ISocketInitConfig {
   }) => void;
   onPresenceChange?: (collaborators: IDocCollabUsers[]) => void;
   onTitleUpdate?: (encryptedTitle: string | null) => void;
+  onWireFormat?: (data: { roomId: string; wireFormat: WireFormat }) => void;
   onSessionTerminated: (data: { roomId: string }) => void;
   onReconnectFailed: () => void;
 }
@@ -293,4 +319,5 @@ export interface IAuthArgs {
   editUcan?: string;
   actorHandle?: string;
   joinOnly?: boolean;
+  wireFormats?: WireFormat[];
 }

--- a/package/sync-local/utils/createAwarenessUpdateHandler.ts
+++ b/package/sync-local/utils/createAwarenessUpdateHandler.ts
@@ -2,11 +2,13 @@ import { encodeAwarenessUpdate, type Awareness } from 'y-protocols/awareness';
 import { toUint8Array } from 'js-base64';
 import { crypto as cryptoUtils } from '../crypto';
 import { SocketClient } from '../socketClient';
+import type { WireFormat } from '../types';
 
 export const createAwarenessUpdateHandler = (
   awareness: Awareness,
   socketClient: SocketClient,
   roomKey: string,
+  getWireFormat: () => WireFormat,
 ) => {
   let pending: number[] = [];
   let timer: ReturnType<typeof setTimeout> | null = null;
@@ -24,6 +26,7 @@ export const createAwarenessUpdateHandler = (
       const encryptedUpdate = cryptoUtils.encryptData(
         toUint8Array(roomKey),
         update,
+        getWireFormat(),
       );
       socketClient.broadcastAwareness(encryptedUpdate);
     }


### PR DESCRIPTION
Adds an xchacha wire format next to the historical ECIES shim: XChaCha20-Poly1305 under an HKDF-SHA256 subkey of the roomKey, tagged FVXC1 so decrypt routes on the string without a flag. The socket client declares both formats on auth, takes the format the server announces, never steps back from xchacha once learned, and reports the value to the host through onHandshakeData and onWireFormat. Every outbound seal (update batches, snapshots, the beacon, awareness, roomInfo, the headless reseed) uses the announced format. A WIRE_FORMAT_UNSUPPORTED refusal is terminal and surfaces as a terminated collab state so the host can prompt a reload.

Fixes the hydration floor on the way: a row that fails to decrypt now pins the floor below it for the rest of the walk, so a later snapshot can never stamp a floorSeq above content this client never applied. A room locked to xchacha whose newest snapshot is still ECIES gets one deferred re-authored snapshot on open, sharing the tail-compaction jitter. Host telemetry callbacks (announced, write, hydrate, refused) are guarded so a throwing host never drops a batch.

Version 4.8.14-xchacha.1.